### PR TITLE
Added AMP mixed precision training support for events

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Ignore everything
+**
+
+# Allow files and directories for Docker build
+!requirements.txt
+!scripts/data/ace-event/requirements.txt
+!scripts/data/ace05/get_corenlp.sh
+!scripts/data/get_scierc.sh
+!dygie
+!scripts/data/shared
+!scripts/data/get_genia.sh
+!scripts/data/genia
+!scripts/data/get_chemprot.sh
+!scripts/data/chemprot
+!scripts/pretrained/get_dygiepp_pretrained.sh
+!scripts/pretrained/get_scibert.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Set-up docker image for DYGIE++.
+FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
+
+# Datasets will be downloaded to the /dygiepp root directory in image.
+# Please mount source code project dir at /dygiepp for using default paths.
+RUN mkdir /dygiepp
+
+# Required-base: set-up shared DYGIE++ modeling environment.
+# GCC and make needed to compile python deps.
+RUN apt-get update && \
+    apt-get -y install gcc make
+RUN conda create --name dygiepp python=3.7 -y
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+# jsonnet has a conflict when installed with pip for now, install from conda.
+RUN conda install -c conda-forge jsonnet -y
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# ACE05-EVENT: set-up environment for pre-processing.
+SHELL ["/bin/bash", "-c"]
+RUN conda create --name ace-event-preprocess python=3.7 -y
+SHELL ["conda", "run", "-n", "ace-event-preprocess", "/bin/bash", "-c"]
+COPY scripts/data/ace-event/requirements.txt /tmp/ace-prep-requirements.txt
+RUN pip install -r /tmp/ace-prep-requirements.txt
+RUN python -m spacy download en
+
+# ACE05 dataset creation: Install CoreNLP (requires Java 1.8+) and zsh.
+SHELL ["/bin/bash", "-c"]
+RUN apt-get install openjdk-8-jdk openjdk-8-jre wget unzip -y
+COPY scripts/data/ace05/get_corenlp.sh /tmp/get_corenlp.sh
+RUN cd /dygiepp/ && bash /tmp/get_corenlp.sh
+RUN conda install -c conda-forge zsh -y
+
+# SciERC, GENIA, ChemProt: Download data.
+# Downloader scripts require wget, unzip, and shared parsing code.
+RUN apt-get install unzip wget -y
+COPY scripts/data/shared /dygiepp/scripts/data/shared
+# SciERC
+COPY scripts/data/get_scierc.sh /tmp/get_scierc.sh
+COPY dygie /dygiepp/dygie
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN cd /dygiepp && bash /tmp/get_scierc.sh
+# GENIA
+COPY scripts/data/get_genia.sh /tmp/get_genia.sh
+COPY scripts/data/genia /dygiepp/scripts/data/genia
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN cd /dygiepp && bash /tmp/get_genia.sh
+# ChemPROT
+COPY scripts/data/get_chemprot.sh /tmp/get_chemprot.sh
+COPY scripts/data/chemprot /dygiepp/scripts/data/chemprot
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN pip install scispacy https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_sm-0.2.5.tar.gz
+RUN cd /dygiepp && bash /tmp/get_chemprot.sh
+
+# Pretrained-models-all-DYGIEPP: Download pre-trained models for all DYGIEPP tasks.
+RUN apt-get install wget -y
+COPY scripts/pretrained/get_dygiepp_pretrained.sh /tmp/get_dygiepp_pretrained.sh
+RUN cd /dygiepp && bash /tmp/get_dygiepp_pretrained.sh
+
+# SciBERT: Download fine-tuned pretrained SciBERT model.
+COPY scripts/pretrained/get_scibert.py /tmp/get_scibert.py
+RUN cd /dygiepp && python /tmp/get_scibert.py
+
+# Required-base: cleanup.
+RUN rm -rf /tmp /dygiepp/{scripts,dygie}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ The necessary dependencies can be installed with `pip install -r requirements.tx
 
 This library relies on [AllenNLP](https://allennlp.org) and uses AllenNLP shell [commands](https://docs.allennlp.org/master/#package-overview) to kick off training, evaluation, and testing.
 
+### Docker build
+A `Dockerfile` is provided with the Pytorch + CUDA + CUDNN base image for a full-stack GPU install.
+It will create conda environments `dygiepp` for modeling & `ace-event-preprocess` for ACE05-Event preprocessing.
+
+By default the build downloads datasets and dependencies for all tasks. 
+This takes a long time and produces a large image, so you will want to comment out unneeded datasets/tasks in the Dockerfile.
+
+- Comment out unneeded task sections in `Dockerfile`.
+- Build container: `docker build --tag dygiepp:dev <dygiepp-repo-dirpath>`
+- Run the container interactively, mount this project dir to /dygiepp/: `docker run --gpus all -it --ipc=host -v <dygiepp-repo-dirpath>:/dygiepp/ --name dygiepp dygiep:dev`
 
 ## Training a model
 

--- a/dygie/models/entity_beam_pruner.py
+++ b/dygie/models/entity_beam_pruner.py
@@ -144,7 +144,7 @@ class Pruner(torch.nn.Module):
         # Make sure that we don't select any masked items by setting their scores to be very
         # negative.  These are logits, typically, so -1e20 should be plenty negative.
         # NOTE(`mask` needs to be a byte tensor now.)
-        scores = util.replace_masked_values(scores, mask.bool(), -1e20)
+        scores = util.replace_masked_values(scores.float(), mask.bool(), -1e20)
 
         # Shape: (batch_size, max_num_items_to_keep, 1)
         _, top_indices = scores.topk(max_items_to_keep, 1)

--- a/dygie/models/events.py
+++ b/dygie/models/events.py
@@ -274,7 +274,7 @@ class EventExtractor(Model):
         trigger_scores = trigger_scorer(trigger_embeddings)
         # Give large negative scores to masked-out elements.
         mask = trigger_mask.unsqueeze(-1)
-        trigger_scores = util.replace_masked_values(trigger_scores, mask.bool(), -1e20)
+        trigger_scores = util.replace_masked_values(trigger_scores.float(), mask.bool(), -1e20)
         dummy_dims = [trigger_scores.size(0), trigger_scores.size(1), 1]
         dummy_scores = trigger_scores.new_zeros(*dummy_dims)
         trigger_scores = torch.cat((dummy_scores, trigger_scores), -1)
@@ -357,10 +357,10 @@ class EventExtractor(Model):
         # TODO(dwadden) Vectorize.
         argument_dict = {}
         argument_scores = output["argument_scores"]
-        predicted_scores_raw, predicted_arguments = argument_scores.max(dim=-1)
+        predicted_scores_raw, predicted_arguments = argument_scores.float().max(dim=-1)
         # The null argument has label -1.
         predicted_arguments -= 1
-        softmax_scores = F.softmax(argument_scores, dim=-1)
+        softmax_scores = F.softmax(argument_scores.float(), dim=-1)
         predicted_scores_softmax, _ = softmax_scores.max(dim=-1)
 
         for i, j in itertools.product(range(output["num_triggers_kept"]),

--- a/dygie/models/ner.py
+++ b/dygie/models/ner.py
@@ -92,7 +92,7 @@ class NERTagger(Model):
         ner_scores = scorer(span_embeddings)
         # Give large negative scores to masked-out elements.
         mask = span_mask.unsqueeze(-1)
-        ner_scores = util.replace_masked_values(ner_scores, mask.bool(), -1e20)
+        ner_scores = util.replace_masked_values(ner_scores.float(), mask.bool(), -1e20)
         # The dummy_scores are the score for the null label.
         dummy_dims = [ner_scores.size(0), ner_scores.size(1), 1]
         dummy_scores = ner_scores.new_zeros(*dummy_dims)

--- a/dygie/models/relation.py
+++ b/dygie/models/relation.py
@@ -148,8 +148,8 @@ class RelationExtractor(Model):
         top_spans = [tuple(x) for x in top_spans.tolist()]
 
         # Iterate over all span pairs and labels. Record the span if the label isn't null.
-        predicted_scores_raw, predicted_labels = relation_scores.max(dim=-1)
-        softmax_scores = F.softmax(relation_scores, dim=-1)
+        predicted_scores_raw, predicted_labels = relation_scores.float().max(dim=-1)
+        softmax_scores = F.softmax(relation_scores.float(), dim=-1)
         predicted_scores_softmax, _ = softmax_scores.max(dim=-1)
         predicted_labels -= 1  # Subtract 1 so that null labels get -1.
 

--- a/scripts/data/get_scierc.sh
+++ b/scripts/data/get_scierc.sh
@@ -17,7 +17,7 @@ tar -xf $out_dir/sciERC_processed.tar.gz -C $out_dir
 rm $out_dir/*.tar.gz
 
 # Normalize by adding dataset name..
-python scripts/data/normalize.py \
+python scripts/data/shared/normalize.py \
     $out_dir/processed_data/json \
     $out_dir/normalized_data/json \
     --file_extension=json \

--- a/scripts/data/sentivent/clean_model_weights.py
+++ b/scripts/data/sentivent/clean_model_weights.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+'''
+Script to clean model weights of unwanted experiment runs.
+!!REMOVES intermediate epoch weights of every training run.!!
+!!REMOVES every final model.tar.gz for every training dir except those in KEEP!!
+
+clean_model_weights.py in dygiepp
+8/11/20 Copyright (c) Gilles Jacobs
+'''
+from pathlib import Path
+
+model_dirp = Path("/home/gilles/repos/dygiepp/models")
+KEEP = [
+    "sentivent-event-nonerforargs",
+    "sentivent-event_args_use_ner_labels:false-loss_weights_events.trigger:1.0-events_context_window:3-loss_weights.ner:0.0001",
+    "ace05-event_args_use_ner_labels:false",
+    "sentivent-finbert-finetune",
+    "sentivent-bert-finetune",
+    "sentivent-event-finbert"
+]
+
+for weight_fp in model_dirp.rglob("*.th"):
+    print("Removed weights", weight_fp)
+    weight_fp.unlink()
+
+for model_fp in model_dirp.rglob("model.tar.gz"):
+    if model_fp.parts[-2] not in KEEP:
+        print("Removed model", model_fp)
+        model_fp.unlink()

--- a/scripts/data/sentivent/merge_ace05_predictions.py
+++ b/scripts/data/sentivent/merge_ace05_predictions.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+'''
+Merge SENTiVENt event annotations with NER and relations produced by the pretrained DYGIE++ ACE05-Event model.
+Requires: a dir with output predictions + parsed gold standard
+
+merge_ace05_predictions.py in dygiepp
+8/11/20 Copyright (c) Gilles Jacobs
+'''
+import json
+from pathlib import Path
+
+if __name__ == "__main__":
+
+    parsed_fp = "/home/gilles/repos/dygiepp/data/sentivent/json/all.jsonl"
+    pred_fp = "/home/gilles/repos/dygiepp/predictions/sentivent-all.jsonl"
+
+    splits = {"train": (0, 228), "dev": (228, 258), "test": (258, 288)}
+
+    with open(pred_fp, "rt") as pred_in:
+        preds = [json.loads(l) for l in pred_in.readlines()]
+
+    with open(parsed_fp, "rt") as parsed_in:
+        parses = [json.loads(l) for l in parsed_in.readlines()]
+
+    merges = []
+    for (parse, pred) in zip(parses, preds):
+        assert parse["doc_key"] == pred["doc_key"]
+        merge = parse.copy()
+        merge["ner"] = pred["predicted_ner"]
+        merges.append(merge)
+
+    opt_dir = Path("/home/gilles/repos/dygiepp/data/sentivent/ner/")
+    with open(opt_dir / "all.jsonl", "wt") as all_out:
+        for d in merges:
+            all_out.write(json.dumps(d) + "\n")
+
+    # split
+    for split_name, (start, end) in splits.items():
+        with open(opt_dir / f"{split_name}.jsonl", "wt") as spl_out:
+            split_data = merges[start:end]
+            for d in split_data:
+                spl_out.write(json.dumps(d) + "\n")

--- a/scripts/data/sentivent/read_aceevent_dataset.py
+++ b/scripts/data/sentivent/read_aceevent_dataset.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+'''
+Dataset inspection script for processed ace05 dataset.
+
+read_aceevent_dataset.py in dygiepp
+8/5/20 Copyright (c) Gilles Jacobs
+'''
+from dygie.data.dataset_readers.data_structures import Dataset
+import spacy
+
+data = Dataset("/home/gilles/repos/dygiepp/data/sentivent/ner/all.jsonl")
+print(data[0])  # Print the first document.
+print(data[0][1].ner)  # Print the named entities in the second sentence of the first document.
+all_argument_roles = set()
+for doc in data:
+    for sen in doc:
+        for ev in sen.events:
+            roles = [arg.role for arg in ev.arguments]
+            all_argument_roles.update(roles)
+
+print(f"{len(all_argument_roles)} roles in train: {all_argument_roles}")

--- a/scripts/data/sentivent/read_event_dataset.py
+++ b/scripts/data/sentivent/read_event_dataset.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+'''
+Dataset inspection script for processed ace05 dataset.
+
+read_event_dataset.py in dygiepp
+8/5/20 Copyright (c) Gilles Jacobs
+'''
+from dygie.data.dataset_readers.data_structures import Dataset
+import spacy
+from collections import Counter
+from pathlib import Path
+
+def count_events(dset):
+    counts = {"sentences": 0,
+              "events": 0,
+              "arguments": 0,
+              "entities": 0,
+    }
+    for doc in dset:
+        for sen in doc.sentences:
+            counts["sentences"] += 1
+            for ev in sen.events:
+                counts["events"] += 1
+                for arg in ev.arguments:
+                    counts["arguments"] += 1
+            for ne in sen.ner:
+                counts["entities"] += 1
+    return counts
+
+
+base_fp = Path("/home/gilles/repos/dygiepp/data/sentivent/ner_with_subtype_args/")
+train = Dataset(base_fp / "train.jsonl")
+dev = Dataset(base_fp / "dev.jsonl")
+test = Dataset(base_fp / "test.jsonl")
+
+base_fp = Path("/home/gilles/repos/dygiepp/data/ace-event/processed-data/default-settings/json")
+train_ace = Dataset(base_fp / "train.json")
+dev_ace = Dataset(base_fp / "dev.json")
+test_ace = Dataset(base_fp / "test.json")
+
+train_c = count_events(train)
+dev_c = count_events(dev)
+test_c = count_events(test)
+train_ace_c = count_events(train_ace)
+dev_ace_c = count_events(dev_ace)
+test_ace_c = count_events(test_ace)
+
+# data = Dataset("/home/gilles/repos/dygiepp/data/sentivent/ner/all.jsonl")
+data_sentivent = train.documents + dev.documents + test.documents
+data_ace = train_ace.documents + dev_ace.documents + test_ace.documents
+data = data_ace
+# print(data[0])  # Print the first document.
+# print(data[0][1].ner)  # Print the named entities in the second sentence of the first document.
+all_argument_roles = set()
+all_arg_event = dict() # all arguments and events counts
+all_event_arg = dict() # all events with arguments
+events = set()
+for doc in data:
+    for sen in doc:
+        events.update(sen.events)
+        for ev in sen.events:
+            roles = [arg.role for arg in ev.arguments]
+            all_argument_roles.update(roles)
+            all_event_arg.setdefault(ev.trigger.label, Counter()).update(roles)
+            for role in roles:
+                all_arg_event.setdefault(role, Counter()).update([ev.trigger.label])
+
+
+print(f"{len(all_argument_roles)} roles in train: {all_argument_roles}")
+
+# print types
+all_arg = ["CAPITAL", "TIME", "PLACE"]
+for_type_table = sorted([(k, sorted([arg for arg in v.keys() if arg not in all_arg])) for k, v in all_event_arg.items()])
+for type, args in for_type_table:
+    print(type)
+    print(f" $\\rightarrow$ {', '.join(args)}")

--- a/scripts/data/sentivent/read_event_dataset.py
+++ b/scripts/data/sentivent/read_event_dataset.py
@@ -28,27 +28,27 @@ def count_events(dset):
     return counts
 
 
-base_fp = Path("/home/gilles/repos/dygiepp/data/sentivent/ner_with_subtype_args/")
+base_fp = Path("/home/gilles/repos/dygiepp-dev/data/sentivent/ner_with_subtype_args/")
 train = Dataset(base_fp / "train.jsonl")
 dev = Dataset(base_fp / "dev.jsonl")
 test = Dataset(base_fp / "test.jsonl")
+data_sentivent = train.documents + dev.documents + test.documents
 
-base_fp = Path("/home/gilles/repos/dygiepp/data/ace-event/processed-data/default-settings/json")
-train_ace = Dataset(base_fp / "train.json")
-dev_ace = Dataset(base_fp / "dev.json")
-test_ace = Dataset(base_fp / "test.json")
-
-train_c = count_events(train)
-dev_c = count_events(dev)
-test_c = count_events(test)
-train_ace_c = count_events(train_ace)
-dev_ace_c = count_events(dev_ace)
-test_ace_c = count_events(test_ace)
+# base_fp_ace = Path("/home/gilles/repos/dygiepp-dev/data/ace-event/collated-data/default-settings/json")
+# train_ace = Dataset(base_fp_ace / "train.json")
+# dev_ace = Dataset(base_fp_ace / "dev.json")
+# test_ace = Dataset(base_fp_ace / "test.json")
+#
+# train_c = count_events(train)
+# dev_c = count_events(dev)
+# test_c = count_events(test)
+# train_ace_c = count_events(train_ace)
+# dev_ace_c = count_events(dev_ace)
+# test_ace_c = count_events(test_ace)
+# data_ace = train_ace.documents + dev_ace.documents + test_ace.documents
 
 # data = Dataset("/home/gilles/repos/dygiepp/data/sentivent/ner/all.jsonl")
-data_sentivent = train.documents + dev.documents + test.documents
-data_ace = train_ace.documents + dev_ace.documents + test_ace.documents
-data = data_ace
+data = data_sentivent
 # print(data[0])  # Print the first document.
 # print(data[0][1].ner)  # Print the named entities in the second sentence of the first document.
 all_argument_roles = set()
@@ -60,6 +60,8 @@ for doc in data:
         events.update(sen.events)
         for ev in sen.events:
             roles = [arg.role for arg in ev.arguments]
+            if 'Buyer' in roles:
+                print(ev)
             all_argument_roles.update(roles)
             all_event_arg.setdefault(ev.trigger.label, Counter()).update(roles)
             for role in roles:

--- a/training_config/template.libsonnet
+++ b/training_config/template.libsonnet
@@ -111,6 +111,7 @@
       }
     },
     trainer: {
+      use_amp: true,
       checkpointer: {
         num_serialized_models_to_keep: 3,
       },


### PR DESCRIPTION
What changed to enable Torch's built-in Nvidia AMP mixed precision training with  AllenNLP (>v1.1.0rc2) for significant speedup:
- Enable amp in config with setting `trainer: { use_amp: true,`
- Fix `RuntimeError: value cannot be converted to type Half without overflow: <value>` errors: added `.float()` call on tensors in reduction operations. Reductions are sensitive to overflow if you are using FP16. All reductions should be performed in FP32 just to make sure to get a valid result. Autograd will rewind this operation in the backward pass so that the model will still be in half precision.

I have only patched calls for training ace-event with default-settings, for other tasks where other reduction functions are called `.float()` should also be added to the tensors.
I have not benchmarked the speedup with AMP on training e.g. Ace-event yet.
In any case this PR is tested and working for training events.