### PR TITLE
Add improved Dockerfile build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Ignore everything
+**
+
+# Allow files and directories for Docker build
+!requirements.txt
+!scripts/data/ace-event/requirements.txt
+!scripts/data/ace05/get_corenlp.sh
+!scripts/data/get_scierc.sh
+!dygie
+!scripts/data/shared
+!scripts/data/get_genia.sh
+!scripts/data/genia
+!scripts/data/get_chemprot.sh
+!scripts/data/chemprot
+!scripts/pretrained/get_dygiepp_pretrained.sh
+!scripts/pretrained/get_scibert.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Set-up docker image for DYGIE++.
+FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
+
+# Datasets will be downloaded to the /dygiepp root directory in image.
+# Please mount source code project dir at /dygiepp for using default paths.
+RUN mkdir /dygiepp
+
+# Required-base: set-up shared DYGIE++ modeling environment.
+# GCC and make needed to compile python deps.
+RUN apt-get update && \
+    apt-get -y install gcc make
+RUN conda create --name dygiepp python=3.7 -y
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+# jsonnet has a conflict when installed with pip for now, install from conda.
+RUN conda install -c conda-forge jsonnet -y
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# ACE05-EVENT: set-up environment for pre-processing.
+SHELL ["/bin/bash", "-c"]
+RUN conda create --name ace-event-preprocess python=3.7 -y
+SHELL ["conda", "run", "-n", "ace-event-preprocess", "/bin/bash", "-c"]
+COPY scripts/data/ace-event/requirements.txt /tmp/ace-prep-requirements.txt
+RUN pip install -r /tmp/ace-prep-requirements.txt
+RUN python -m spacy download en
+
+# ACE05 dataset creation: Install CoreNLP (requires Java 1.8+) and zsh.
+SHELL ["/bin/bash", "-c"]
+RUN apt-get install openjdk-8-jdk openjdk-8-jre wget unzip -y
+COPY scripts/data/ace05/get_corenlp.sh /tmp/get_corenlp.sh
+RUN cd /dygiepp/ && bash /tmp/get_corenlp.sh
+RUN conda install -c conda-forge zsh -y
+
+# SciERC, GENIA, ChemProt: Download data.
+# Downloader scripts require wget, unzip, and shared parsing code.
+RUN apt-get install unzip wget -y
+COPY scripts/data/shared /dygiepp/scripts/data/shared
+# SciERC
+COPY scripts/data/get_scierc.sh /tmp/get_scierc.sh
+COPY dygie /dygiepp/dygie
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN cd /dygiepp && bash /tmp/get_scierc.sh
+# GENIA
+COPY scripts/data/get_genia.sh /tmp/get_genia.sh
+COPY scripts/data/genia /dygiepp/scripts/data/genia
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN cd /dygiepp && bash /tmp/get_genia.sh
+# ChemPROT
+COPY scripts/data/get_chemprot.sh /tmp/get_chemprot.sh
+COPY scripts/data/chemprot /dygiepp/scripts/data/chemprot
+ENV PYTHONPATH="${PYTHONPATH}:/dygiepp"
+SHELL ["conda", "run", "-n", "dygiepp", "/bin/bash", "-c"]
+RUN pip install scispacy https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_sm-0.2.5.tar.gz
+RUN cd /dygiepp && bash /tmp/get_chemprot.sh
+
+# Pretrained-models-all-DYGIEPP: Download pre-trained models for all DYGIEPP tasks.
+RUN apt-get install wget -y
+COPY scripts/pretrained/get_dygiepp_pretrained.sh /tmp/get_dygiepp_pretrained.sh
+RUN cd /dygiepp && bash /tmp/get_dygiepp_pretrained.sh
+
+# SciBERT: Download fine-tuned pretrained SciBERT model.
+COPY scripts/pretrained/get_scibert.py /tmp/get_scibert.py
+RUN cd /dygiepp && python /tmp/get_scibert.py
+
+# Required-base: cleanup.
+RUN rm -rf /tmp /dygiepp/{scripts,dygie}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ The necessary dependencies can be installed with `pip install -r requirements.tx
 
 This library relies on [AllenNLP](https://allennlp.org) and uses AllenNLP shell [commands](https://docs.allennlp.org/master/#package-overview) to kick off training, evaluation, and testing.
 
+### Docker build
+A `Dockerfile` is provided with the Pytorch + CUDA + CUDNN base image for a full-stack GPU install.
+It will create conda environments `dygiepp` for modeling & `ace-event-preprocess` for ACE05-Event preprocessing.
+
+By default the build downloads datasets and dependencies for all tasks. 
+This takes a long time and produces a large image, so you will want to comment out unneeded datasets/tasks in the Dockerfile.
+
+- Comment out unneeded task sections in `Dockerfile`.
+- Build container: `docker build --tag dygiepp:dev <dygiepp-repo-dirpath>`
+- Run the container interactively, mount this project dir to /dygiepp/: `docker run --gpus all -it --ipc=host -v <dygiepp-repo-dirpath>:/dygiepp/ --name dygiepp dygiep:dev`
 
 ## Training a model
 

--- a/scripts/data/get_scierc.sh
+++ b/scripts/data/get_scierc.sh
@@ -17,7 +17,7 @@ tar -xf $out_dir/sciERC_processed.tar.gz -C $out_dir
 rm $out_dir/*.tar.gz
 
 # Normalize by adding dataset name..
-python scripts/data/normalize.py \
+python scripts/data/shared/normalize.py \
     $out_dir/processed_data/json \
     $out_dir/normalized_data/json \
     --file_extension=json \


### PR DESCRIPTION
Reworked Docker build:
- `.dockerignore` now specifies which files to load into build context explicitly for faster startup.
- `Dockerfile` now has more modular steps for each task/dataset/model.
- `README.md` has been updated with Dockerbuild instructions.
- `scripts/data/get_scierc.sh` contained an outdated path which is fixed.

All steps have been tested, except downloading the pretrained models because it takes long to download them all.