### PR TITLE
Added AMP automatic mixed precision training for events

### DIFF
--- a/dygie/models/entity_beam_pruner.py
+++ b/dygie/models/entity_beam_pruner.py
@@ -144,7 +144,7 @@ class Pruner(torch.nn.Module):
         # Make sure that we don't select any masked items by setting their scores to be very
         # negative.  These are logits, typically, so -1e20 should be plenty negative.
         # NOTE(`mask` needs to be a byte tensor now.)
-        scores = util.replace_masked_values(scores, mask.bool(), -1e20)
+        scores = util.replace_masked_values(scores.float(), mask.bool(), -1e20)
 
         # Shape: (batch_size, max_num_items_to_keep, 1)
         _, top_indices = scores.topk(max_items_to_keep, 1)

--- a/dygie/models/events.py
+++ b/dygie/models/events.py
@@ -274,7 +274,7 @@ class EventExtractor(Model):
         trigger_scores = trigger_scorer(trigger_embeddings)
         # Give large negative scores to masked-out elements.
         mask = trigger_mask.unsqueeze(-1)
-        trigger_scores = util.replace_masked_values(trigger_scores, mask.bool(), -1e20)
+        trigger_scores = util.replace_masked_values(trigger_scores.float(), mask.bool(), -1e20)
         dummy_dims = [trigger_scores.size(0), trigger_scores.size(1), 1]
         dummy_scores = trigger_scores.new_zeros(*dummy_dims)
         trigger_scores = torch.cat((dummy_scores, trigger_scores), -1)
@@ -357,10 +357,10 @@ class EventExtractor(Model):
         # TODO(dwadden) Vectorize.
         argument_dict = {}
         argument_scores = output["argument_scores"]
-        predicted_scores_raw, predicted_arguments = argument_scores.max(dim=-1)
+        predicted_scores_raw, predicted_arguments = argument_scores.float().max(dim=-1)
         # The null argument has label -1.
         predicted_arguments -= 1
-        softmax_scores = F.softmax(argument_scores, dim=-1)
+        softmax_scores = F.softmax(argument_scores.float(), dim=-1)
         predicted_scores_softmax, _ = softmax_scores.max(dim=-1)
 
         for i, j in itertools.product(range(output["num_triggers_kept"]),

--- a/dygie/models/ner.py
+++ b/dygie/models/ner.py
@@ -92,7 +92,7 @@ class NERTagger(Model):
         ner_scores = scorer(span_embeddings)
         # Give large negative scores to masked-out elements.
         mask = span_mask.unsqueeze(-1)
-        ner_scores = util.replace_masked_values(ner_scores, mask.bool(), -1e20)
+        ner_scores = util.replace_masked_values(ner_scores.float(), mask.bool(), -1e20)
         # The dummy_scores are the score for the null label.
         dummy_dims = [ner_scores.size(0), ner_scores.size(1), 1]
         dummy_scores = ner_scores.new_zeros(*dummy_dims)

--- a/dygie/models/relation.py
+++ b/dygie/models/relation.py
@@ -148,8 +148,8 @@ class RelationExtractor(Model):
         top_spans = [tuple(x) for x in top_spans.tolist()]
 
         # Iterate over all span pairs and labels. Record the span if the label isn't null.
-        predicted_scores_raw, predicted_labels = relation_scores.max(dim=-1)
-        softmax_scores = F.softmax(relation_scores, dim=-1)
+        predicted_scores_raw, predicted_labels = relation_scores.float().max(dim=-1)
+        softmax_scores = F.softmax(relation_scores.float(), dim=-1)
         predicted_scores_softmax, _ = softmax_scores.max(dim=-1)
         predicted_labels -= 1  # Subtract 1 so that null labels get -1.
 

--- a/training_config/template.libsonnet
+++ b/training_config/template.libsonnet
@@ -111,6 +111,7 @@
       }
     },
     trainer: {
+      use_amp: true,
       checkpointer: {
         num_serialized_models_to_keep: 3,
       },


### PR DESCRIPTION
What changed to enable Torch's built-in Nvidia AMP automatic mixed precision training with  AllenNLP (>v1.1.0rc2) for significant speedup:
- Enable amp in config with setting `trainer: { use_amp: true,`
- Fix `RuntimeError: value cannot be converted to type Half without overflow: <value>` errors: added `.float()` call on tensors in reduction operations. Reductions are sensitive to overflow if you are using FP16. All reductions should be performed in FP32 just to make sure to get a valid result. Autograd will rewind this operation in the backward pass so that the model will still be in half precision.

I have only patched calls for training ace-event with default-settings, for other tasks where other reduction functions are called `.float()` should also be added to the tensors.
I have not benchmarked the speedup with AMP on training e.g. Ace-event yet.
In any case this PR is tested and working for training events.