### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Modeling
 
 allennlp==1.1.0
-allennlp_models==1.0
+allennlp_models==1.1.0
 
 # Data munging
 


### PR DESCRIPTION
pip installation fails when allennlp is set to v1.1.0 and allennlp_models is v1.0. I've updated allennlp_models to be from the same release cycle and that fixed it. 

```
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of allennlp to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 6) and allennlp==1.1.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested allennlp==1.1.0
    allennlp-models 1.0.0 depends on allennlp==1.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
````