### PR TITLE
Fix constant 0 value for total_original_ents

### DIFF
--- a/scripts/new-dataset/annotated_doc.py
+++ b/scripts/new-dataset/annotated_doc.py
@@ -33,7 +33,7 @@ class AnnotatedDoc:
         self.coref = coref  # True if EquivRels should be treated as corefs
         self.nlp = nlp
         self.dropped_ents = 0
-        self.total_original_ents = 0
+        self.total_original_ents = total_original_ents
 
 
     @classmethod


### PR DESCRIPTION
Fixes a typo where no matter what the actual value of `total_original_ents` was, 0 was assigned. This meant the script reported `{x} of 0 entities were dropped` instead of the actual number of total original entities.