### PR TITLE
bugfix for multi-datasets training of event extraction

### DIFF
--- a/dygie/models/events.py
+++ b/dygie/models/events.py
@@ -63,7 +63,7 @@ class EventExtractor(Model):
             self._trigger_pruners[trigger_namespace] = make_pruner(trigger_candidate_feedforward)
             # The trigger scorer.
             trigger_feedforward = make_feedforward(input_dim=token_emb_dim)
-            self._trigger_scorers[namespace] = torch.nn.Sequential(
+            self._trigger_scorers[trigger_namespace] = torch.nn.Sequential(
                 TimeDistributed(trigger_feedforward),
                 TimeDistributed(torch.nn.Linear(trigger_feedforward.get_output_dim(),
                                                 self._n_trigger_labels[trigger_namespace] - 1)))


### PR DESCRIPTION
**Bug description**: training for the task of event extraction using more than one dataset results in a model that is actuallly trained on only one of the EE datasets, selected at random. 

**How to reproduce**: create a set of train/valid/test jsonl files containing at least 2 event extraction datasets and start training a model on EE. Trig and Args losses and R/P/F1 metrics will stay at 0 for all but one dataset.

**How to fix**: a typo was found in the `dygie/models/events/EventExtractor` constructor resulting in an incorrect key for the `self._trigger_scorers` ModuleDict. The key was set to `namespace` when it should have been set to `trigger_namespace`.