### PR TITLE
Ensure that disjoint entities and relations that depend on them are dropped

### DIFF
--- a/dygie/tests/data/annotated_doc_test.py
+++ b/dygie/tests/data/annotated_doc_test.py
@@ -94,7 +94,9 @@ class TestBinRel(unittest.TestCase):
                "T4\tPerson 59 62\tShe\n"
                "T5\tPersonnel.Election 67 74\telected\n"
                "T6\tYear 78 82\t2017\n"
+               "T7\tCity 0 7;19 23\tSeattle city\n"
                "R1\tMayor-Of Arg1:T2 Arg2:T3\n"
+               "R2\tis Arg1:T7 Arg2:T1\n"
                "E1\tPersonnel.Election:T5 Person:T4 Year:T6\n"
                "*\tEQUIV T1 T3\n"
                "*\tEQUIV T2 T4\n")
@@ -113,6 +115,7 @@ class TestBinRel(unittest.TestCase):
 
         # Set up relation
         self.rel1 = ad.BinRel("R1\tMayor-Of Arg1:T2 Arg2:T3".split())
+        self.rel2 = ad.BinRel("R2\tis Arg1:T7 Arg2:T1".split())
 
         # Right answer
         self.relations = [[], [[6, 7, 9, 11, "Mayor-Of"]], []]
@@ -154,6 +157,13 @@ class TestBinRel(unittest.TestCase):
         self.assertEqual(self.rel1.arg1, self.annotated_doc.ents[1])
         self.assertEqual(self.rel1.arg2, self.annotated_doc.ents[2])
 
+    def test_set_arg_objects_disjoint(self):
+
+        self.rel2.set_arg_objects(self.annotated_doc.ents)
+
+        self.assertEqual(self.rel2.arg1, None)
+        self.assertEqual(self.rel2.arg2, self.annotated_doc.ents[0])
+
     def test_set_arg_objects_missing_arg(self):
 
         self.rel1.set_arg_objects(self.missing_annotated_doc.ents)
@@ -164,9 +174,10 @@ class TestBinRel(unittest.TestCase):
     def test_format_bin_rels_dygiepp(self):
 
         self.rel1.set_arg_objects(self.annotated_doc.ents)
+        self.rel2.set_arg_objects(self.annotated_doc.ents)
         self.annotated_doc.char_to_token()
         relations, dropped_rels = ad.BinRel.format_bin_rels_dygiepp(
-            [self.rel1], self.sent_idx_tups)
+            [self.rel1, self.rel2], self.sent_idx_tups)
 
         self.assertEqual(relations, self.relations)
 

--- a/scripts/new-dataset/annotated_doc.py
+++ b/scripts/new-dataset/annotated_doc.py
@@ -342,20 +342,31 @@ class BinRel:
         """
         Given a list of Ent objects, replaces the string ID for arg1 and arg2
         taken from the original annotation with the Ent object instance that
-        represents that entity.
+        represents that entity. Replaces the string with None if no argument is
+        found.
 
         parameters:
             arg_list, list of Ent instances: entities from the same .ann file
 
         returns: None
         """
+        found_arg1 = False
+        found_arg2 = False
         for ent in arg_list:
 
             if ent.ID == self.arg1:
                 self.arg1 = ent
+                found_arg1 = True
 
             elif ent.ID == self.arg2:
                 self.arg2 = ent
+                found_arg2 = True
+
+        # Replace any args that weren't found with None
+        if not found_arg1:
+            self.arg1 = None
+        if not found_arg2:
+            self.arg2 = None
 
     @staticmethod
     def format_bin_rels_dygiepp(rel_list, sent_idx_tups):
@@ -382,6 +393,15 @@ class BinRel:
             # Check first entity to see if relation is in this sentence
             sent_rels = []
             for rel in rel_list:
+                # Check to see if either entity as dropped because disjoint
+                if rel.arg1 is None or rel.arg2 is None:
+                    warnings.warn(
+                            'One or more of the argument entities for '
+                            f'relation {rel.ID} was dropped because it was '
+                            'disjoint. This relation will also be dropped as '
+                            'a result.')
+                    dropped_rels += 1
+                    continue
                 # Check to make sure both entities actually have token starts
                 if rel.arg1.tok_start == None or rel.arg2.tok_start == None:
                     warnings.warn(

--- a/scripts/new-dataset/brat_to_input.py
+++ b/scripts/new-dataset/brat_to_input.py
@@ -5,9 +5,11 @@ annotation to the input format for dygiepp.
 Assumes the input .ann files correspond to the format described in
 https://brat.nlplab.org/standoff.html
 
-Supports conversion of .ann files including entities, binary relations,
-equivalence relations, and events. Does NOT support formatting attribute
-and modification annotations, normalization annotations, or note annotations.
+Supports conversion of .ann files including continuous entities, binary
+relations, equivalence relations, and events. Does NOT support formatting
+attribute and modification annotations, normalization annotations, or note
+annotations. Disjoint entities will also be dropped, as they are not supported
+by DyGIE++.
 
 Author: Serena G. Lotreck
 """


### PR DESCRIPTION
Fixes a bug where disjoint entities cause an error if a relation depends on them, rather than the relation getting dropped.